### PR TITLE
Mark Minestrix as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
+  "end-of-life": "This application is no longer maintained.",
   "only-arches": [
     "x86_64"
   ],


### PR DESCRIPTION
> This project is on stall as I don't have the bandwidth to work on this.
> 
> More concerning is that I don't own anymore the domain name (henri2h.fr) associated to this flathub app.
> 
> This project has been renamed and development moved to github: https://github.com/henri2h/PIAF
> 
> I guess for the following reasons it would make sence to remove this app from flathub.
> 
> Thanks

https://github.com/flathub/fr.henri2h.minestrix/issues/2#issuecomment-3706938112